### PR TITLE
Add explicit build when starting auth env

### DIFF
--- a/scripts/authoring_env.sh
+++ b/scripts/authoring_env.sh
@@ -14,7 +14,7 @@ help () {
     "
 }
 
-if [ $# -ne 1 ]; then 
+if [ $# -ne 1 ]; then
     help
     echo "Please provide one of the valid commands."
     exit 1
@@ -23,7 +23,7 @@ fi
 if [ $ACTION == "up" ]; then
     echo "Starting authoring environment"
 
-    docker compose up -d
+    docker compose up --build -d
     docker compose exec moodle php admin/cli/install_database.php --agree-license --fullname="Local Dev" --shortname="Local Dev" --summary="Local Dev" --adminpass="admin" --adminemail="admin@acmeinc.com"
     docker compose exec postgres psql -U moodle -d moodle -c "update mdl_config set value='1' where name='forcelogin'"
     docker compose exec moodle php admin/cli/purge_caches.php


### PR DESCRIPTION
This PR adds the `--build` flag when running `docker compose up` so that when / if we make changes to container images in the future they will be automatically incorporated when running `./scripts/authoring_env.sh up`.