### PR TITLE
Remove CI check for JSON files being up-to-date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,6 @@ jobs:
           python-version: "3.10"
       - name: Install raise-mbtools
         run: pip install git+https://github.com/openstax/raise-mbtools@main
-      - name: Check that JSON is up-to-date
-        run: |
-          html-to-json html json
-          git diff --exit-code --quiet
       - name: Validate mbz
         run: |
           validate-mbz-html mbz errors.csv mbz --no-style


### PR DESCRIPTION
Previously this check was imposed to help remind devs as needed.
However, now that CMs will be making content edits, we'll decouple
PRs with content changes (created by CMs) from deployment PRs
(created by devs).