### PR TITLE
Fail deployment if version prefix already exists

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -15,7 +15,7 @@ phases:
       - aws s3 cp --cache-control max-age=86400 --recursive json/ "s3://$CONTENT_S3_BUCKET/contents/raise/$VERSION/"
     on-failure: ABORT
     finally:
-      - "([[ $CODEBUILD_BUILD_SUCCEEDING != 1 ]] && curl -X POST -H 'Content-type: application/json' --data '{\"text\":\"Error in k12-contents-raise pipeline!\"}' $SLACK_WEBHOOKURL) || true"
+      - "if [[ $CODEBUILD_BUILD_SUCCEEDING != 1 ]]; then curl -X POST -H 'Content-type: application/json' --data '{\"text\":\"Error in k12-contents-raise pipeline!\"}' $SLACK_WEBHOOKURL; fi"
   post_build:
     commands:
       - ls json/ > json_files.txt


### PR DESCRIPTION
While this is unlikely to occur, it is possible that in the future we may hit a collision when using the short ref as the version component in our S3 prefix. This change modifies the deployment to check if a target version prefix exists, and if so, to fail without uploading. That should trigger us to then increase the prefix size without any unintentional surprises.