### PR TITLE
Add .gitattributes file to use LF on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
A common issue for authors on Windows machines is their specific settings for core.autocrlf can cause problems (the usual being CRLF breaking bash scripts in Docker containers). I'm adding this file to try and help create consistent behavior since it should take precedence. The reason for eol=lf is that we expect Windows users to employ WSL, Docker Desktop, and Unix friendly tools like Git Bash and VS Code, so there should be no real need to convert to CRLF in those environments.