### PR TITLE
2.3.2-SE-feedback-edits

### DIFF
--- a/html/cc98afef-8ec5-45b7-a3f2-955512400b3c.html
+++ b/html/cc98afef-8ec5-45b7-a3f2-955512400b3c.html
@@ -15,7 +15,7 @@
   </div>
   <div class="os-raise-ib-input-ack">
     <p>Compare your answer:</p>
-    <p> Compare your answer: Your answer may vary, but here is a sample. Diego added the two equations, and the sum is an equation with only one variable, \(y\), which can be solved. He then substituted the \(y\)-value into the first equation and solved for \(x\).</p>
+    <p>Your answer may vary, but here is a sample. Diego added the two equations, and the sum is an equation with only one variable, \(y\), which can be solved. He then substituted the \(y\)-value into the first equation and solved for \(x\).</p>
   </div>
 </div>
 <!--Interaction End --> 
@@ -228,7 +228,7 @@
   </div>
   <div class="os-raise-ib-input-ack">
     <p>Compare your answer:</p>
-    <p>&nbsp; Your answer may vary, but here is a sample. Diego&rsquo;s method does not work because adding the two equations doesn&rsquo;t get us anywhere. The sum is \(16x+12y=44\), which doesn&rsquo;t make it easier to solve.</p>
+    <p>Your answer may vary, but here is a sample. Diego&rsquo;s method does not work because adding the two equations doesn&rsquo;t get us anywhere. The sum is \(16x+12y=44\), which doesn&rsquo;t make it easier to solve.</p>
     <p>It works if the second equation is subtracted from the first instead of added to the first. The difference is \(10y=30\), or \(y=3\). If we substitute 3 for \(y\) in one of the original equations, we get \(x=12\).</p>
   </div>
 </div>


### PR DESCRIPTION
Fixed this issue:

"In feedback for Q1, delete the second instance of “Compare your answer:”

In feedback for Q11, there is an extra space before “Your answer may vary…”"