### PR TITLE
TG-2.3.2-Q9-feedback

### DIFF
--- a/html/ebf14197-5921-4b0b-978f-80b3138ceab5.html
+++ b/html/ebf14197-5921-4b0b-978f-80b3138ceab5.html
@@ -92,7 +92,7 @@
   </li>
 </ol>
 <p><strong>Answer:</strong></p>
-<p> \(x=12 \)</p>
+<p> \(x=\frac12 \)</p>
 
 <ol  class="os-raise-noindent" start="10">
   <li>


### PR DESCRIPTION
Q9: changed feedback from "x=12" to "x=1/2" (using KaTeX)