### PR TITLE
Revert "Implement work around for docker compose bug"

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-POSTGRES_USER=moodle
-POSTGRES_PASSWORD=moodledbpassword
-POSTGRES_DB=moodle
-CONTENT_VARIANT=

--- a/authoring/docker/.env
+++ b/authoring/docker/.env
@@ -1,1 +1,4 @@
-../../.env
+POSTGRES_USER=moodle
+POSTGRES_PASSWORD=moodledbpassword
+POSTGRES_DB=moodle
+CONTENT_VARIANT=

--- a/scripts/authoring_env.sh
+++ b/scripts/authoring_env.sh
@@ -71,8 +71,8 @@ if [ "$ACTION" == "set-variant" ]; then
 
     set -e
 
-    sed 's/CONTENT_VARIANT=.*/CONTENT_VARIANT='"$VARIANT"'/' .env > .env.variant
-    docker compose --env-file .env.variant up --build -d
+    sed 's/CONTENT_VARIANT=.*/CONTENT_VARIANT='"$VARIANT"'/' ./authoring/docker/.env > ./authoring/docker/.env.variant
+    docker compose --env-file ./authoring/docker/.env.variant up --build -d
 
     exit 0
 fi


### PR DESCRIPTION
This reverts commit f381afe41ec9d35dc65faf3cc0c036f388edc1f4.

The [original commit / PR](https://github.com/openstax/k12-contents-raise/pull/1494) was found to impact Windows users, and the work around should no longer be required for newer versions of docker compose.